### PR TITLE
Remove QR code redirect, update docs to indicate this is handled on frontend

### DIFF
--- a/docs/source/backend/qr-codes.rst
+++ b/docs/source/backend/qr-codes.rst
@@ -15,7 +15,7 @@ There are two fields on the ``SpecimenRecord`` model that can be viewed in the W
 not meant to be edited manually: ``short_code`` and ``qr_code``.
 
 The ``short_code`` is just the unique specimen identifier (``usi``) lowercased and without the
-hyphen (so ``MEM-000001`` becomes ``mem000001``). This short code is used to generate a shortened
+hyphen (so ``MEM-000001`` becomes ``000001``). This short code is used to generate a shortened
 URL, as shorter URLs make it easier to generate a smaller QR code that is still scannable.
 
 The ``qr_code`` field is an ``ImageField`` that stores the generated QR code image. You are not
@@ -96,14 +96,9 @@ How the QR Codes Work
 
 Because I needed the QR codes to be small enough to fit on a specimen label, I needed to shorten the
 URLs encoded while still taking the user to the correct specimen page on the frontend when scanned.
+The URLs encoded in the QR codes are in the following format:
+``www.memcollection.com/s/{short_code}``. Navigating to a URL like this will redirect the user to
+the corresponding URL: ``https://www.memcollection.com/specimens/{full_usi}``.
 
-To accomplish this, I set up a redirect view (located in ``specimens/views.py``). The URLs encoded
-in the QR codes are in the following format: ``api.memcollection.com/{short_code}``. Navigating to a
-URL like this will redirect the user to the corresponding frontend URL:
-``https://www.memcollection.com/specimens/{full_usi}/``. Because this redirect service runs on
-the backend, these QR codes will only work so long as my backend service remains running (in other
-words, they will likely only be of use to me while I'm still around to keep the backend service up
-and running).
-
-
-
+The actual redirect lives in a ``.htaccess`` file within the Eleventy frontend. Because it's just a
+static file, if my backend server were to go down, the QR codes will still work.

--- a/memcollection/urls.py
+++ b/memcollection/urls.py
@@ -9,7 +9,7 @@ from wagtail.documents import urls as wagtaildocs_urls
 # from wagtail_footnotes import urls as footnotes_urls
 
 from search import views as search_views
-from specimens.views import export_qr_codes_pdf, specimen_short_redirect
+from specimens.views import export_qr_codes_pdf
 from .api import api_router
 
 urlpatterns = [
@@ -20,7 +20,6 @@ urlpatterns = [
     # path("footnotes/", include(footnotes_urls)),
     path("search/", search_views.search, name="search"),
     path("api/v2/", api_router.urls),
-    path("<str:short_code>/", specimen_short_redirect, name="specimen_short_redirect"),
 ]
 
 

--- a/specimens/models.py
+++ b/specimens/models.py
@@ -425,10 +425,10 @@ class SpecimenRecord(TimeStampMixin):
     def generate_short_code(self):
         """Generates a short code for a specimen that can be used in a shortened URL.
 
-        Example: MEM-000001 -> mem000001
+        Example: MEM-000001 -> 000001
         """
 
-        self.short_code = self.usi.lower().replace("-", "")
+        self.short_code = self.usi.split("-")[1]
 
     def generate_qr_code(self):
         """Generates a QR code for a specimen that, when scanned with a smart phone's camera,
@@ -436,7 +436,7 @@ class SpecimenRecord(TimeStampMixin):
 
         self.generate_short_code()
 
-        short_url = f"api.memcollection.com/{self.short_code}"
+        short_url = f"www.memcollection.com/s/{self.short_code}"
 
         qr = qrcode.QRCode(
             version=1,

--- a/specimens/tests/test_models.py
+++ b/specimens/tests/test_models.py
@@ -79,7 +79,7 @@ class SpecimenRecordTestCase(TestCase):
 
         specimen = SpecimenRecord.objects.get(usi="MEM-000001")
         specimen.generate_short_code()
-        self.assertEqual(specimen.short_code, "mem000001")
+        self.assertEqual(specimen.short_code, "000001")
 
     def test_generate_qr_code_filename(self):
         """Ensures a QR code is generated with the format 'qr_codes/qr_{usi}***.png'."""
@@ -95,7 +95,7 @@ class SpecimenRecordTestCase(TestCase):
         specimen = SpecimenRecord.objects.get(usi="MEM-000001")
         self.assertFalse(specimen.short_code)
         specimen.generate_qr_code()
-        self.assertEqual(specimen.short_code, "mem000001")
+        self.assertEqual(specimen.short_code, "000001")
 
     def test_identified(self):
         """Ensures the identified property returns the correct boolean state."""

--- a/specimens/tests/test_views.py
+++ b/specimens/tests/test_views.py
@@ -1,55 +1,7 @@
-from django.test import Client, TestCase, override_settings
+from django.test import Client, TestCase
 from django.contrib.auth.models import User
 
 from specimens.models import SpecimenRecord
-
-
-@override_settings(
-    STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage",
-    DEBUG=True,
-    WHITENOISE_AUTOREFRESH=True,
-)
-class SpecimenShortRedirectTestCase(TestCase):
-    """A test case for the specimen_short_redirect view."""
-
-    fixtures = [
-        "countries.json",
-        "states.json",
-        "counties.json",
-        "localities.json",
-        "gps_coordinates.json",
-        "collecting_trips.json",
-        "orders.json",
-        "families.json",
-        "subfamilies.json",
-        "tribes.json",
-        "genera.json",
-        "species.json",
-        "subspecies.json",
-        "people.json",
-        "specimen_records.json",
-    ]
-
-    def setUp(self):
-        """Set up test data."""
-
-        self.client = Client()
-        self.specimen = SpecimenRecord.objects.get(usi="MEM-000001")
-        self.specimen.generate_short_code()
-        self.specimen.save()
-
-    def test_redirect_to_correct_url(self):
-        """Ensures a user is redirected to full specimen URL from short code."""
-
-        response = self.client.get(f"/{self.specimen.short_code}/", follow=False)
-        expected_url = "https://www.memcollection.com/specimens/mem-000001/"
-        self.assertRedirects(response, expected_url, fetch_redirect_response=False)
-
-    def test_redirect_nonexistent_specimen_raises_404(self):
-        """Ensures a Http404 is raised for a nonexistent specimen."""
-
-        response = self.client.get("/nonexistent/", follow=False)
-        self.assertEqual(response.status_code, 404)
 
 
 class ExportQrCodesToPdfTestCase(TestCase):

--- a/specimens/views.py
+++ b/specimens/views.py
@@ -2,8 +2,7 @@ import os
 
 from core.utils.helpers import get_fields
 from django.contrib.admin.views.decorators import staff_member_required
-from django.http import Http404, HttpResponse
-from django.shortcuts import redirect
+from django.http import HttpResponse
 from io import BytesIO
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
@@ -53,17 +52,6 @@ class SpecimenRecordAPIViewSet(BaseAPIViewSet):
             return filterset.qs.distinct()
 
         return queryset
-
-
-def specimen_short_redirect(request, short_code):
-    """Redirect short code URL to full specimen URL."""
-    try:
-        specimen = SpecimenRecord.objects.get(short_code=short_code)
-        return redirect(
-            f"https://www.memcollection.com/specimens/{specimen.usi.lower()}/"
-        )
-    except SpecimenRecord.DoesNotExist:
-        raise Http404("Specimen not found")
 
 
 @staff_member_required


### PR DESCRIPTION
No longer should need the redirect on the backend, since everything is now handled on the frontend via a `.htaccess` file